### PR TITLE
Update API Fast Mock description

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,7 +431,7 @@
                     </div>
                     <h4>API Fast Mock</h4>
                     <p>
-                        API Fast Mock é um servidor de mock HTTP leve escrito com FastAPI. Em vez de armazenar as configurações de mock no servidor, cada configuração é comprimida em um token autossuficiente que descreve completamente o comportamento do endpoint. Essa abordagem sem estado facilita compartilhar, versionar e reproduzir mocks com uma única URL.
+                        API Fast Mock é um servidor de mock HTTP leve. Em vez de armazenar as configurações de mock no servidor, cada configuração é comprimida em um token autossuficiente que descreve completamente o comportamento do endpoint. Essa abordagem sem estado facilita compartilhar, versionar e reproduzir mocks com uma única URL.
                     </p>
                     <span class="project-link">
                         Explorar projeto <i class="fas fa-arrow-right"></i>


### PR DESCRIPTION
## Summary
- refine API Fast Mock blurb to remove FastAPI mention while keeping the token-based explanation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6855f59cc9448330922c07f3aac5d37f