### PR TITLE
Refactor portfolio content for authenticity and clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,13 +20,13 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <title>Bruno Kawakami - Arquiteto de Futuros Digitais</title>
+    <title>Bruno Kawakami</title>
 
     <!-- SEO: Metatags básicas -->
     <meta name="description"
-        content="Bruno Kawakami: CTO visionário transformando o impossível em código. Líder do exit de R$180M da D4Sign, criador de soluções que impactam milhões." />
+        content="Bruno Kawakami. Ex-CTO e sócio da D4Sign (exit de R$180M para o grupo Zucchetti). Atualmente Head de Engenharia, Dados e IA na Faculdade São Leopoldo Mandic." />
     <meta name="keywords"
-        content="Inovação, IA, Inteligência Artificial, Crescimento Exponencial, Empreendedorismo, Transformação Digital, CTO, Liderança, Tecnologia, Bruno Kawakami" />
+        content="Bruno Kawakami, CTO, engenharia de software, dados, inteligência artificial, D4Sign, Faculdade São Leopoldo Mandic" />
     <meta name="author" content="Bruno Kawakami" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://www.brunokawakami.com" />
@@ -34,17 +34,17 @@
     <!-- Open Graph (Facebook, LinkedIn, etc.) -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.brunokawakami.com" />
-    <meta property="og:title" content="Bruno Kawakami - Arquiteto de Futuros Digitais" />
+    <meta property="og:title" content="Bruno Kawakami" />
     <meta property="og:description"
-        content="CTO visionário transformando o impossível em código. Líder do exit de R$180M da D4Sign, criador de soluções que impactam milhões." />
+        content="Ex-CTO e sócio da D4Sign (exit de R$180M para o grupo Zucchetti). Atualmente Head de Engenharia, Dados e IA na Faculdade São Leopoldo Mandic." />
     <meta property="og:image" content="https://www.brunokawakami.com/foto_bruno.jpeg" />
 
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://www.brunokawakami.com" />
-    <meta name="twitter:title" content="Bruno Kawakami - Arquiteto de Futuros Digitais" />
+    <meta name="twitter:title" content="Bruno Kawakami" />
     <meta name="twitter:description"
-        content="CTO visionário transformando o impossível em código. Líder do exit de R$180M da D4Sign, criador de soluções que impactam milhões." />
+        content="Ex-CTO e sócio da D4Sign (exit de R$180M para o grupo Zucchetti). Atualmente Head de Engenharia, Dados e IA na Faculdade São Leopoldo Mandic." />
     <meta name="twitter:image" content="https://www.brunokawakami.com/foto_bruno.jpeg" />
 
     <!-- Marcação de dados estruturados (JSON-LD) -->
@@ -54,8 +54,8 @@
       "@type": "Person",
       "name": "Bruno Kawakami",
       "url": "https://www.brunokawakami.com",
-      "jobTitle": "CTO e Arquiteto de Soluções em IA",
-      "description": "Bruno Kawakami é um CTO visionário e arquiteto de soluções digitais, especializado em IA e transformação empresarial com histórico comprovado de sucesso.",
+      "jobTitle": "Head de Engenharia, Dados e IA",
+      "description": "Bruno Kawakami. Ex-CTO e sócio da D4Sign (exit de R$180M para o grupo Zucchetti). Atualmente Head de Engenharia, Dados e IA na Faculdade São Leopoldo Mandic e partner na BF Holding.",
       "sameAs": [
         "https://www.linkedin.com/in/bruno-akio-kawakami/"
       ]
@@ -105,17 +105,17 @@
         <div class="hero-overlay"></div>
 
         <div class="hero-content">
-            <div class="hero-badge mono" data-aos="fade-up">CTO & Arquiteto de IA</div>
+            <div class="hero-badge mono" data-aos="fade-up">Ex-D4Sign · Engenharia, Dados e IA</div>
             <h1 class="hero-title" data-aos="fade-up" data-aos-delay="100">
-                Transformando o impossível em linhas de código
+                Bruno Kawakami
             </h1>
             <p class="hero-subtitle" data-aos="fade-up" data-aos-delay="200">
-                Sou Bruno Kawakami. Construo pontes entre a visão e a execução,
-                liderando equipes que transformam empresas através da tecnologia.
+                Ex-CTO e sócio da D4Sign até o exit de R$ 180M para o grupo Zucchetti em 2025.
+                Hoje, Head de Engenharia, Dados e IA na Faculdade São Leopoldo Mandic e partner na BF Holding.
             </p>
             <div class="hero-actions" data-aos="fade-up" data-aos-delay="300">
                 <a href="#sobre" class="btn btn-glow">
-                    Conheça minha história
+                    Sobre mim
                 </a>
                 <a href="https://labs.brunokawakami.com" target="_blank" class="btn btn-glow btn-glow--labs">
                     Labs <i class="fas fa-arrow-up-right-from-square" style="font-size:0.6rem;margin-left:6px;opacity:0.5"></i>
@@ -124,14 +124,14 @@
         </div>
     </section>
 
-    <!-- 2. Números que contam histórias -->
+    <!-- 2. Marcos -->
     <section id="impacto" style="background: var(--section-bg);" data-aos="fade-up">
         <div class="container">
             <div class="section-header">
-                <div class="section-badge">// IMPACTO</div>
-                <h2 class="section-title">Números que contam histórias</h2>
+                <div class="section-badge">// MARCOS</div>
+                <h2 class="section-title">Marcos</h2>
                 <p class="section-subtitle">
-                    Cada métrica representa vidas transformadas e negócios revolucionados
+                    Apenas o que é verificável externamente.
                 </p>
             </div>
 
@@ -141,34 +141,10 @@
                         <i class="fas fa-rocket"></i>
                     </div>
                     <div class="stat-value">R$ 180M</div>
-                    <div class="stat-label">Exit estratégico da D4Sign</div>
+                    <div class="stat-label">Exit da D4Sign para o grupo Zucchetti (2025)</div>
                 </div>
 
                 <div class="stat-card" data-aos="zoom-in" data-aos-delay="100">
-                    <div class="stat-icon">
-                        <i class="fas fa-chart-line"></i>
-                    </div>
-                    <div class="stat-value">400%</div>
-                    <div class="stat-label">Crescimento anual alcançado</div>
-                </div>
-
-                <div class="stat-card" data-aos="zoom-in" data-aos-delay="200">
-                    <div class="stat-icon">
-                        <i class="fas fa-brain"></i>
-                    </div>
-                    <div class="stat-value">200+</div>
-                    <div class="stat-label">Algoritmos de IA implementados</div>
-                </div>
-
-                <div class="stat-card" data-aos="zoom-in" data-aos-delay="300">
-                    <div class="stat-icon">
-                        <i class="fas fa-users"></i>
-                    </div>
-                    <div class="stat-value">10M+</div>
-                    <div class="stat-label">Usuários impactados</div>
-                </div>
-
-                <div class="stat-card" data-aos="zoom-in" data-aos-delay="400">
                     <div class="stat-icon">
                         <i class="fas fa-lightbulb"></i>
                     </div>
@@ -176,12 +152,12 @@
                     <div class="stat-label">Patentes registradas</div>
                 </div>
 
-                <div class="stat-card" data-aos="zoom-in" data-aos-delay="500">
+                <div class="stat-card" data-aos="zoom-in" data-aos-delay="200">
                     <div class="stat-icon">
-                        <i class="fas fa-code"></i>
+                        <i class="fas fa-newspaper"></i>
                     </div>
-                    <div class="stat-value">15x</div>
-                    <div class="stat-label">Aceleração em projetos de IA</div>
+                    <div class="stat-value">4</div>
+                    <div class="stat-label">Matérias publicadas na imprensa (links abaixo)</div>
                 </div>
             </div>
         </div>
@@ -196,26 +172,23 @@
                 </div>
                 <div class="about-text" data-aos="fade-up" data-aos-delay="100">
                     <div class="section-badge">// SOBRE MIM</div>
-                    <h2 class="section-title">Da visão à execução</h2>
+                    <h2 class="section-title">Sobre mim</h2>
                     <div class="about-content">
                         <p>
-                            Minha jornada começou com uma simples pergunta:
-                            <strong>"E se a tecnologia pudesse fazer mais?"</strong>
+                            Trabalho com software há mais de uma década, em papéis de engenharia,
+                            arquitetura e liderança técnica.
                         </p>
                         <p>
-                            Como CTO da D4Sign, não apenas liderei o desenvolvimento técnico -
-                            <span class="about-highlight">arquitetei a transformação</span> que levou a empresa
-                            de uma startup promissora a um exit de R$ 180 milhões para o grupo Zucchetti.
+                            Entre 2021 e 2025 fui <span class="about-highlight">CTO e sócio da D4Sign</span>,
+                            até o exit de R$ 180 milhões para o grupo Zucchetti.
                         </p>
                         <p>
-                            Com mais de uma década construindo o futuro, desenvolvi uma filosofia simples:
-                            <strong>tecnologia sem propósito é apenas código</strong>. Por isso, cada algoritmo
-                            que escrevo, cada equipe que lidero e cada decisão que tomo é guiada por um
-                            único princípio: criar impacto real na vida das pessoas.
+                            Atualmente sou Head de Engenharia, Dados e IA na Faculdade São Leopoldo Mandic
+                            e partner na BF Holding.
                         </p>
                         <p>
-                            Hoje, combino expertise técnica profunda com visão estratégica de negócios,
-                            transformando desafios complexos em soluções elegantes que escalam para milhões.
+                            Gosto de trabalhar em problemas concretos: sistemas que precisam rodar em
+                            produção, times que precisam funcionar e decisões técnicas com consequência.
                         </p>
                     </div>
                 </div>
@@ -223,39 +196,37 @@
         </div>
     </section>
 
-    <!-- 4. Entre os líderes que moldam o futuro -->
+    <!-- 4. Menção na Forbes -->
     <section id="forbes" style="background: var(--section-bg);" data-aos="fade-up">
         <div class="container">
             <div class="row align-items-center">
                 <div class="col-lg-6" data-aos="fade-up">
                     <div class="section-badge">// FORBES</div>
-                    <h2 class="section-title mb-4">Entre os líderes que moldam o futuro</h2>
+                    <h2 class="section-title mb-4">Menção na Forbes Brasil</h2>
                     <p class="mb-4">
-                        Ser reconhecido pela Forbes entre os principais CTOs do Brasil não é apenas
-                        uma conquista pessoal - é a validação de uma jornada dedicada a
-                        <span class="about-highlight">transformar empresas através da tecnologia</span>.
+                        Tive meu nome citado pela Forbes Brasil em matéria sobre liderança em
+                        tecnologia. A imagem ao lado é o registro da menção.
                     </p>
                     <p>
-                        Este convite exclusivo me colocou ao lado dos visionários que estão
-                        redefinindo o cenário tecnológico brasileiro, reforçando meu compromisso
-                        de continuar liderando com inovação e propósito.
+                        Deixo aqui porque é um marco pessoal — sem pretensão de transformar a citação
+                        em mais do que foi.
                     </p>
                 </div>
                 <div class="col-lg-6" data-aos="fade-up">
-                    <img src="forbes_bruno.png" alt="Forbes Recognition" class="img-fluid forbes-image" />
+                    <img src="forbes_bruno.png" alt="Menção na Forbes Brasil" class="img-fluid forbes-image" />
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- 5. Voz da inovação na mídia -->
+    <!-- 5. Imprensa -->
     <section id="midia" data-aos="fade-up">
         <div class="container">
             <div class="section-header">
-                <div class="section-badge">// RECONHECIMENTO</div>
-                <h2 class="section-title">Voz da inovação na mídia</h2>
+                <div class="section-badge">// IMPRENSA</div>
+                <h2 class="section-title">Na imprensa</h2>
                 <p class="section-subtitle">
-                    Compartilhando insights sobre o futuro da tecnologia
+                    Matérias e artigos publicados.
                 </p>
             </div>
 
@@ -264,41 +235,41 @@
                     target="_blank" class="media-card">
                     <img src="cnn.png" alt="CNN" class="media-logo" />
                     <h5>CNN Brasil</h5>
-                    <p>Desvendando os mistérios da IA: por que chatbots alucinam</p>
+                    <p>Por que chatbots de IA dão respostas erradas ("alucinação").</p>
                 </a>
 
                 <a href="https://www.saudebusiness.com/artigos/ia-na-medicina-um-aliado-nao-uma-ameaca/" target="_blank"
                     class="media-card">
                     <img src="saude.png" alt="Saúde Business" class="media-logo" />
                     <h5>Saúde Business</h5>
-                    <p>IA na medicina: construindo o futuro da saúde</p>
+                    <p>IA na medicina: um aliado, não uma ameaça.</p>
                 </a>
 
                 <a href="https://olhardigital.com.br/2022/08/17/colunistas/onde-esta-toda-inteligencia-artificial-no-mundo-moderno/"
                     target="_blank" class="media-card">
                     <img src="olhar.jpg" alt="Olhar Digital" class="media-logo" />
                     <h5>Olhar Digital</h5>
-                    <p>A onipresença silenciosa da inteligência artificial</p>
+                    <p>Onde está toda a inteligência artificial no mundo moderno.</p>
                 </a>
 
                 <a href="https://tiinside.com.br/16/10/2024/de-y-a-alfa-geracoes-mais-novas-estao-sofrendo-o-impacto-da-ai-no-qi/"
                     target="_blank" class="media-card">
                     <img src="ti.png" alt="TI Inside" class="media-logo" />
                     <h5>TI Inside</h5>
-                    <p>O impacto da IA nas novas gerações</p>
+                    <p>De Y a Alfa: o impacto da IA no QI das novas gerações.</p>
                 </a>
             </div>
         </div>
     </section>
 
-    <!-- 6. Cada desafio, uma oportunidade -->
+    <!-- 6. Trajetória -->
     <section id="jornada" style="background: var(--section-bg);" data-aos="fade-up">
         <div class="container">
             <div class="section-header">
-                <div class="section-badge">// JORNADA</div>
-                <h2 class="section-title">Cada desafio, uma oportunidade</h2>
+                <div class="section-badge">// TRAJETÓRIA</div>
+                <h2 class="section-title">Trajetória</h2>
                 <p class="section-subtitle">
-                    Uma trajetória construída transformando empresas e liderando com propósito
+                    Onde trabalhei e o que fiz.
                 </p>
             </div>
 
@@ -310,10 +281,9 @@
                         <div class="timeline-date">2025 - Atual</div>
                         <h4 class="timeline-title">Faculdade São Leopoldo Mandic • Head de Engenharia, Dados e IA</h4>
                         <p class="timeline-description">
-                            Revolucionando a educação médica e odontológica através da inteligência
-                            artificial. Criando plataformas de aprendizado adaptativo e ferramentas
-                            de diagnóstico assistido por IA que preparam os profissionais de saúde
-                            para o futuro da medicina digital.
+                            Lidero as áreas de engenharia de software, dados e IA. Responsável pelas
+                            plataformas digitais de apoio ao ensino médico e odontológico e pela
+                            estratégia de IA aplicada à instituição.
                         </p>
                     </div>
                 </div>
@@ -322,12 +292,10 @@
                     <div class="timeline-dot"></div>
                     <div class="timeline-content">
                         <div class="timeline-date">2025 - Atual</div>
-                        <h4 class="timeline-title">BF Holding • Partner & Executive</h4>
+                        <h4 class="timeline-title">BF Holding • Partner</h4>
                         <p class="timeline-description">
-                            Liderando a transformação digital do grupo através de iniciativas
-                            tecnológicas estratégicas. Desenvolvendo novos modelos de negócio
-                            baseados em IA e criando sinergias entre as empresas do portfólio
-                            para acelerar crescimento e inovação.
+                            Sócio. Participo das decisões de tecnologia e de novos produtos das
+                            empresas do portfólio.
                         </p>
                     </div>
                 </div>
@@ -340,9 +308,9 @@
                         <div class="timeline-date">2021 - 2025</div>
                         <h4 class="timeline-title">D4Sign • CTO & Sócio</h4>
                         <p class="timeline-description">
-                            Arquitetei o crescimento exponencial que levou ao exit de R$ 180M.
-                            Liderei a transformação tecnológica, expansão internacional e
-                            implementação de IA que revolucionou o mercado de assinaturas digitais.
+                            CTO e sócio até o exit de R$ 180 milhões para o grupo Zucchetti em 2025.
+                            Liderei o time de engenharia, a arquitetura da plataforma de assinatura
+                            eletrônica e os projetos de IA embarcados no produto.
                         </p>
                     </div>
                 </div>
@@ -353,9 +321,9 @@
                         <div class="timeline-date">2020 - 2021</div>
                         <h4 class="timeline-title">dr.consulta • Head de Arquitetura & CISO</h4>
                         <p class="timeline-description">
-                            Revolucionei a infraestrutura tecnológica, migrando para cloud e
-                            criando as bases para IA em saúde. Estabeleci o departamento de
-                            segurança, garantindo proteção de dados de milhões de pacientes.
+                            Head de arquitetura e CISO. Conduzi a migração para cloud e estruturei
+                            a área de segurança da informação, incluindo o programa de proteção de
+                            dados de pacientes.
                         </p>
                     </div>
                 </div>
@@ -366,9 +334,9 @@
                         <div class="timeline-date">2018 - 2020</div>
                         <h4 class="timeline-title">Sodexo • Global Solutions Architect</h4>
                         <p class="timeline-description">
-                            Projetei soluções globais que impactaram operações em 80 países.
-                            Liderei a modernização de sistemas legados e a criação de
-                            plataformas de pagamento inteligentes.
+                            Arquiteto global de soluções. Trabalhei na modernização de sistemas
+                            legados e em plataformas de pagamento e benefícios usadas pela
+                            operação internacional.
                         </p>
                     </div>
                 </div>
@@ -379,9 +347,8 @@
                         <div class="timeline-date">2018</div>
                         <h4 class="timeline-title">Grupo DASA • Líder Técnico</h4>
                         <p class="timeline-description">
-                            Pioneiro na digitalização da saúde diagnóstica. Criei plataformas
-                            multi-cloud que processavam milhões de exames, estabelecendo novos
-                            padrões de eficiência no setor.
+                            Líder técnico em projetos de digitalização do fluxo diagnóstico.
+                            Atuei em plataformas multi-cloud de processamento de exames.
                         </p>
                     </div>
                 </div>
@@ -389,14 +356,14 @@
         </div>
     </section>
 
-    <!-- 7. Criando soluções que inspiram -->
+    <!-- 7. Projetos pessoais -->
     <section id="projetos" data-aos="fade-up">
         <div class="container">
             <div class="section-header">
                 <div class="section-badge">// PROJETOS PESSOAIS</div>
-                <h2 class="section-title">Criando soluções que inspiram</h2>
+                <h2 class="section-title">Projetos pessoais</h2>
                 <p class="section-subtitle">
-                    Projetos nascidos da paixão por resolver problemas reais com tecnologia elegante
+                    Coisas que construí nas horas vagas.
                 </p>
             </div>
 
@@ -407,13 +374,11 @@
                     </div>
                     <h4>ChessFrame</h4>
                     <p>
-                        Transforme suas partidas de xadrez em vídeos cinematográficos.
-                        Simplesmente insira a notação dos seus jogos e o ChessFrame
-                        gera automaticamente vídeos profissionais das partidas,
-                        perfeitos para análise, ensino ou compartilhamento.
+                        Você cola a notação de uma partida de xadrez e o ChessFrame gera
+                        um vídeo da partida automaticamente.
                     </p>
                     <span class="project-link">
-                        Explorar projeto <i class="fas fa-arrow-right"></i>
+                        Abrir projeto <i class="fas fa-arrow-right"></i>
                     </span>
                 </a>
 
@@ -424,13 +389,11 @@
                     </div>
                     <h4>GoneSheet</h4>
                     <p>
-                        Um frontend completo para planilhas temporárias, projetado
-                        para prototipagem rápida e cálculos instantâneos. Ideal
-                        para quando você precisa de uma planilha poderosa sem
-                        a complexidade de configurações permanentes.
+                        Planilha web descartável para prototipagem rápida e contas pontuais,
+                        sem conta e sem persistência.
                     </p>
                     <span class="project-link">
-                        Explorar projeto <i class="fas fa-arrow-right"></i>
+                        Abrir projeto <i class="fas fa-arrow-right"></i>
                     </span>
                 </a>
 
@@ -441,13 +404,12 @@
                     </div>
                     <h4>API Fast Mock</h4>
                     <p>
-                        API Fast Mock é um servidor de mock HTTP leve. Em vez de armazenar as configurações de mock no
-                        servidor, cada configuração é comprimida em um token autossuficiente que descreve completamente
-                        o comportamento do endpoint. Essa abordagem sem estado facilita compartilhar, versionar e
-                        reproduzir mocks com uma única URL.
+                        Servidor de mock HTTP sem estado. Cada configuração é comprimida em
+                        um token autossuficiente na própria URL, o que facilita compartilhar
+                        e versionar mocks.
                     </p>
                     <span class="project-link">
-                        Explorar projeto <i class="fas fa-arrow-right"></i>
+                        Abrir projeto <i class="fas fa-arrow-right"></i>
                     </span>
                 </a>
                 <a href="https://kaleidoimages.ai" target="_blank" class="project-card" data-aos="zoom-in"
@@ -457,13 +419,11 @@
                     </div>
                     <h4>KaleidoImages</h4>
                     <p>
-                        Repositório público com API e mais de 5.000 imagens únicas
-                        geradas por IA no meu laboratório. Um recurso aberto para
-                        desenvolvedores, designers e criadores que precisam de
-                        conteúdo visual de alta qualidade para seus projetos.
+                        Banco público com mais de 5.000 imagens geradas por IA no meu
+                        laboratório, com API aberta.
                     </p>
                     <span class="project-link">
-                        Explorar projeto <i class="fas fa-arrow-right"></i>
+                        Abrir projeto <i class="fas fa-arrow-right"></i>
                     </span>
                 </a>
                 <a href="https://dropp.news" target="_blank" class="project-card" data-aos="zoom-in"
@@ -473,86 +433,69 @@
                     </div>
                     <h4>Dropp.news</h4>
                     <p>
-                        Portal de notícias ultradinâmico que entrega informação em stories
-                        e threads, com conteúdo gerado e curado por IA para manter você
-                        atualizado em segundos.
+                        Agregador de notícias em formato de stories e threads, com curadoria
+                        assistida por IA.
                     </p>
                     <span class="project-link">
-                        Explorar projeto <i class="fas fa-arrow-right"></i>
+                        Abrir projeto <i class="fas fa-arrow-right"></i>
                     </span>
                 </a>
             </div>
         </div>
     </section>
 
-    <!-- 8. Paixões que me definem -->
+    <!-- 8. Além do código -->
     <section id="skills" style="background: var(--section-bg);" data-aos="fade-up">
         <div class="container">
             <div class="section-header">
                 <div class="section-badge">// ALÉM DO CÓDIGO</div>
-                <h2 class="section-title">Paixões que me definem</h2>
+                <h2 class="section-title">Além do código</h2>
             </div>
 
             <div class="skills-grid">
                 <div class="skill-item">
                     <i class="fas fa-music skill-icon"></i>
                     <div>
-                        <h5>Música Clássica & Violino</h5>
-                        <p>A disciplina das partituras reflete no código</p>
-                    </div>
-                </div>
-
-                <div class="skill-item">
-                    <i class="fas fa-brain skill-icon"></i>
-                    <div>
-                        <h5>Psicologia da Tecnologia</h5>
-                        <p>Entendendo o impacto humano da inovação</p>
+                        <h5>Violino</h5>
+                        <p>Estudei violino por 6 anos. Tenho um Farotte Celeste de 1928.</p>
                     </div>
                 </div>
 
                 <div class="skill-item">
                     <i class="fas fa-flask skill-icon"></i>
                     <div>
-                        <h5>Laboratório de IA</h5>
-                        <p>Onde o futuro é prototipado hoje</p>
-                    </div>
-                </div>
-
-                <div class="skill-item">
-                    <i class="fas fa-network-wired skill-icon"></i>
-                    <div>
-                        <h5>IoT & Automação</h5>
-                        <p>Transformando espaços em ambientes inteligentes</p>
+                        <h5>Laboratório</h5>
+                        <p>Mantenho um laboratório pessoal em labs.brunokawakami.com com experimentos em IA.</p>
                     </div>
                 </div>
 
                 <div class="skill-item">
                     <i class="fas fa-graduation-cap skill-icon"></i>
                     <div>
-                        <h5>Aprendizado Contínuo</h5>
-                        <p>FIAP, IFSP e a universidade da vida</p>
+                        <h5>Formação</h5>
+                        <p>IFSP e FIAP.</p>
                     </div>
                 </div>
 
                 <div class="skill-item">
                     <i class="fas fa-globe skill-icon"></i>
                     <div>
-                        <h5>Poliglota Digital</h5>
-                        <p>Fluente em 3 idiomas e infinitas linguagens</p>
+                        <h5>Idiomas</h5>
+                        <p>Três idiomas no dia a dia.</p>
                     </div>
                 </div>
             </div>
         </div>
     </section>
 
-    <!-- 9. Vamos construir o futuro juntos? -->
+    <!-- 9. Contato -->
     <section id="contato" data-aos="fade-up">
         <div class="container">
             <div class="section-header">
                 <div class="section-badge">// CONTATO</div>
-                <h2 class="section-title">Vamos construir o futuro juntos?</h2>
+                <h2 class="section-title">Contato</h2>
                 <p class="section-subtitle">
-                    Sempre aberto para conversas sobre tecnologia, inovação e novos desafios
+                    Aberto para conversas sobre projetos e colaborações.
                 </p>
             </div>
 
@@ -595,7 +538,7 @@
     <!-- 10. Footer -->
     <footer>
         <div class="container">
-            <p class="mb-0">&copy; 2024 Bruno Kawakami • Arquitetando o amanhã, hoje</p>
+            <p class="mb-0">&copy; 2026 Bruno Kawakami</p>
         </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -105,13 +105,13 @@
         <div class="hero-overlay"></div>
 
         <div class="hero-content">
-            <div class="hero-badge mono" data-aos="fade-up">Ex-D4Sign · Engenharia, Dados e IA</div>
+            <div class="hero-badge mono" data-aos="fade-up">Engenharia, Dados e IA</div>
             <h1 class="hero-title" data-aos="fade-up" data-aos-delay="100">
                 Bruno Kawakami
             </h1>
             <p class="hero-subtitle" data-aos="fade-up" data-aos-delay="200">
-                Ex-CTO e sócio da D4Sign até o exit de R$ 180M para o grupo Zucchetti em 2025.
-                Hoje, Head de Engenharia, Dados e IA na Faculdade São Leopoldo Mandic e partner na BF Holding.
+                Head de Engenharia, Dados e IA na Faculdade São Leopoldo Mandic
+                e partner na BF Holding.
             </p>
             <div class="hero-actions" data-aos="fade-up" data-aos-delay="300">
                 <a href="#sobre" class="btn btn-glow">


### PR DESCRIPTION
## Summary
Comprehensive refactor of the portfolio website to present a more authentic, factual representation of Bruno Kawakami's professional background and achievements. The changes shift from aspirational marketing language to concrete, verifiable accomplishments.

## Key Changes

**Content & Messaging:**
- Simplified page title and meta descriptions to focus on factual information rather than marketing taglines
- Updated hero section with straightforward positioning: "Ex-D4Sign · Engenharia, Dados e IA" instead of "CTO & Arquiteto de IA"
- Replaced aspirational hero title with simple name "Bruno Kawakami"
- Rewrote about section to emphasize concrete work experience over transformational narratives

**Metrics & Achievements:**
- Renamed "Números que contam histórias" section to "Marcos" with subtitle "Apenas o que é verificável externamente"
- Removed unverifiable metrics (400% growth, 200+ AI algorithms, 10M+ users, 15x acceleration)
- Retained only externally verifiable achievements: R$180M exit, 3 patents, 4 press mentions
- Updated stat labels with specific dates and details (e.g., "Exit da D4Sign para o grupo Zucchetti (2025)")

**Professional History:**
- Streamlined timeline descriptions to focus on actual responsibilities rather than transformational impact
- Updated job titles and descriptions to be more precise (e.g., "Partner & Executive" → "Partner")
- Replaced flowery descriptions with concrete deliverables and scope

**Media & Recognition:**
- Renamed "Voz da inovação na mídia" to "Na imprensa"
- Updated press article descriptions to be more factual and less promotional
- Reframed Forbes section from "Entre os líderes que moldam o futuro" to "Menção na Forbes Brasil" with honest context

**Personal Projects & Interests:**
- Simplified project descriptions to focus on functionality rather than aspirational benefits
- Updated "Paixões que me definem" to "Além do código" with more straightforward descriptions
- Changed "Explorar projeto" to "Abrir projeto" for consistency

**Footer & General:**
- Updated copyright year to 2026
- Simplified footer tagline from "Arquitetando o amanhã, hoje" to simple copyright notice
- Adjusted section subtitles throughout to be more direct and less marketing-focused

## Implementation Details
All changes maintain the existing HTML structure and styling while replacing content. The refactor prioritizes transparency and verifiable facts over marketing narratives, creating a more professional and trustworthy presentation.

https://claude.ai/code/session_01P66gLT3cNTgVAwfqH2rD2K