### PR TITLE
Refina copy do site: tom mais sóbrio, remove hype

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,11 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />
     <meta http-equiv="Expires" content="0" />
-    <title>Bruno Kawakami - Arquiteto de Futuros Digitais</title>
+    <title>Bruno Kawakami — CTO e Engenheiro de IA</title>
 
     <!-- SEO: Metatags básicas -->
     <meta name="description"
-        content="Bruno Kawakami: CTO visionário transformando o impossível em código. Líder do exit de R$180M da D4Sign, criador de soluções que impactam milhões." />
+        content="Bruno Kawakami. CTO e engenheiro de IA. Ex-CTO e sócio da D4Sign (exit de R$180M para o grupo Zucchetti)." />
     <meta name="keywords"
         content="Inovação, IA, Inteligência Artificial, Crescimento Exponencial, Empreendedorismo, Transformação Digital, CTO, Liderança, Tecnologia, Bruno Kawakami" />
     <meta name="author" content="Bruno Kawakami" />
@@ -34,17 +34,17 @@
     <!-- Open Graph (Facebook, LinkedIn, etc.) -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.brunokawakami.com" />
-    <meta property="og:title" content="Bruno Kawakami - Arquiteto de Futuros Digitais" />
+    <meta property="og:title" content="Bruno Kawakami — CTO e Engenheiro de IA" />
     <meta property="og:description"
-        content="CTO visionário transformando o impossível em código. Líder do exit de R$180M da D4Sign, criador de soluções que impactam milhões." />
+        content="CTO e engenheiro de IA. Ex-CTO e sócio da D4Sign (exit de R$180M para o grupo Zucchetti). Lidero times em engenharia, dados e IA." />
     <meta property="og:image" content="https://www.brunokawakami.com/foto_bruno.jpeg" />
 
     <!-- Twitter Cards -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://www.brunokawakami.com" />
-    <meta name="twitter:title" content="Bruno Kawakami - Arquiteto de Futuros Digitais" />
+    <meta name="twitter:title" content="Bruno Kawakami — CTO e Engenheiro de IA" />
     <meta name="twitter:description"
-        content="CTO visionário transformando o impossível em código. Líder do exit de R$180M da D4Sign, criador de soluções que impactam milhões." />
+        content="CTO e engenheiro de IA. Ex-CTO e sócio da D4Sign (exit de R$180M para o grupo Zucchetti). Lidero times em engenharia, dados e IA." />
     <meta name="twitter:image" content="https://www.brunokawakami.com/foto_bruno.jpeg" />
 
     <!-- Marcação de dados estruturados (JSON-LD) -->
@@ -55,7 +55,7 @@
       "name": "Bruno Kawakami",
       "url": "https://www.brunokawakami.com",
       "jobTitle": "CTO e Arquiteto de Soluções em IA",
-      "description": "Bruno Kawakami é um CTO visionário e arquiteto de soluções digitais, especializado em IA e transformação empresarial com histórico comprovado de sucesso.",
+      "description": "Bruno Kawakami — CTO e engenheiro de IA. Ex-CTO e sócio da D4Sign.",
       "sameAs": [
         "https://www.linkedin.com/in/bruno-akio-kawakami/"
       ]
@@ -105,17 +105,17 @@
         <div class="hero-overlay"></div>
 
         <div class="hero-content">
-            <div class="hero-badge mono" data-aos="fade-up">CTO & Arquiteto de IA</div>
+            <div class="hero-badge mono" data-aos="fade-up">CTO e Engenheiro de IA</div>
             <h1 class="hero-title" data-aos="fade-up" data-aos-delay="100">
-                Transformando o impossível em linhas de código
+                Construo produtos e lidero times em IA, dados e engenharia.
             </h1>
             <p class="hero-subtitle" data-aos="fade-up" data-aos-delay="200">
-                Sou Bruno Kawakami. Construo pontes entre a visão e a execução,
-                liderando equipes que transformam empresas através da tecnologia.
+                Sou Bruno Kawakami. Há mais de dez anos trabalhando em engenharia e, nos últimos
+                anos, liderando times. Fui CTO e sócio da D4Sign até o exit de R$180M para o grupo Zucchetti.
             </p>
             <div class="hero-actions" data-aos="fade-up" data-aos-delay="300">
                 <a href="#sobre" class="btn btn-glow">
-                    Conheça minha história
+                    Minha trajetória
                 </a>
                 <a href="https://labs.brunokawakami.com" target="_blank" class="btn btn-glow btn-glow--labs">
                     Labs <i class="fas fa-arrow-up-right-from-square" style="font-size:0.6rem;margin-left:6px;opacity:0.5"></i>
@@ -128,10 +128,10 @@
     <section id="impacto" style="background: var(--section-bg);" data-aos="fade-up">
         <div class="container">
             <div class="section-header">
-                <div class="section-badge">// IMPACTO</div>
-                <h2 class="section-title">Números que contam histórias</h2>
+                <div class="section-badge">// EM NÚMEROS</div>
+                <h2 class="section-title">Marcos da trajetória</h2>
                 <p class="section-subtitle">
-                    Cada métrica representa vidas transformadas e negócios revolucionados
+                    Só o que é público e verificável.
                 </p>
             </div>
 
@@ -141,47 +141,31 @@
                         <i class="fas fa-rocket"></i>
                     </div>
                     <div class="stat-value">R$ 180M</div>
-                    <div class="stat-label">Exit estratégico da D4Sign</div>
+                    <div class="stat-label">Exit da D4Sign para o grupo Zucchetti (2025)</div>
                 </div>
 
                 <div class="stat-card" data-aos="zoom-in" data-aos-delay="100">
                     <div class="stat-icon">
-                        <i class="fas fa-chart-line"></i>
+                        <i class="fas fa-user-tie"></i>
                     </div>
-                    <div class="stat-value">400%</div>
-                    <div class="stat-label">Crescimento anual alcançado</div>
+                    <div class="stat-value">4 anos</div>
+                    <div class="stat-label">CTO e sócio da D4Sign (2021–2025)</div>
                 </div>
 
                 <div class="stat-card" data-aos="zoom-in" data-aos-delay="200">
                     <div class="stat-icon">
-                        <i class="fas fa-brain"></i>
+                        <i class="fas fa-users"></i>
                     </div>
-                    <div class="stat-value">200+</div>
-                    <div class="stat-label">Algoritmos de IA implementados</div>
+                    <div class="stat-value">10+ anos</div>
+                    <div class="stat-label">Liderando times de engenharia</div>
                 </div>
 
                 <div class="stat-card" data-aos="zoom-in" data-aos-delay="300">
-                    <div class="stat-icon">
-                        <i class="fas fa-users"></i>
-                    </div>
-                    <div class="stat-value">10M+</div>
-                    <div class="stat-label">Usuários impactados</div>
-                </div>
-
-                <div class="stat-card" data-aos="zoom-in" data-aos-delay="400">
                     <div class="stat-icon">
                         <i class="fas fa-lightbulb"></i>
                     </div>
                     <div class="stat-value">3</div>
                     <div class="stat-label">Patentes registradas</div>
-                </div>
-
-                <div class="stat-card" data-aos="zoom-in" data-aos-delay="500">
-                    <div class="stat-icon">
-                        <i class="fas fa-code"></i>
-                    </div>
-                    <div class="stat-value">15x</div>
-                    <div class="stat-label">Aceleração em projetos de IA</div>
                 </div>
             </div>
         </div>
@@ -196,26 +180,27 @@
                 </div>
                 <div class="about-text" data-aos="fade-up" data-aos-delay="100">
                     <div class="section-badge">// SOBRE MIM</div>
-                    <h2 class="section-title">Da visão à execução</h2>
+                    <h2 class="section-title">Sobre mim</h2>
                     <div class="about-content">
                         <p>
-                            Minha jornada começou com uma simples pergunta:
-                            <strong>"E se a tecnologia pudesse fazer mais?"</strong>
+                            Trabalho com engenharia de software há mais de uma década. Passei os últimos
+                            anos liderando times — arquitetura, dados, IA, segurança — em empresas de
+                            tamanhos e indústrias bem diferentes.
                         </p>
                         <p>
-                            Como CTO da D4Sign, não apenas liderei o desenvolvimento técnico -
-                            <span class="about-highlight">arquitetei a transformação</span> que levou a empresa
-                            de uma startup promissora a um exit de R$ 180 milhões para o grupo Zucchetti.
+                            Entre 2021 e 2025 fui
+                            <span class="about-highlight">CTO e sócio da D4Sign</span>, plataforma brasileira
+                            de assinatura digital. Conduzi a engenharia durante o ciclo que culminou no exit
+                            de R$180M para o grupo italiano Zucchetti.
                         </p>
                         <p>
-                            Com mais de uma década construindo o futuro, desenvolvi uma filosofia simples:
-                            <strong>tecnologia sem propósito é apenas código</strong>. Por isso, cada algoritmo
-                            que escrevo, cada equipe que lidero e cada decisão que tomo é guiada por um
-                            único princípio: criar impacto real na vida das pessoas.
+                            Hoje lidero engenharia, dados e IA na Faculdade São Leopoldo Mandic e atuo como
+                            partner na BF Holding. Também mantenho um laboratório pessoal de IA em
+                            <a href="https://labs.brunokawakami.com" target="_blank">labs.brunokawakami.com</a>.
                         </p>
                         <p>
-                            Hoje, combino expertise técnica profunda com visão estratégica de negócios,
-                            transformando desafios complexos em soluções elegantes que escalam para milhões.
+                            Gosto de construir produto de verdade — sistema que aguenta escala, time que
+                            funciona, decisão técnica que se sustenta depois que o hype passa.
                         </p>
                     </div>
                 </div>
@@ -229,16 +214,9 @@
             <div class="row align-items-center">
                 <div class="col-lg-6" data-aos="fade-up">
                     <div class="section-badge">// FORBES</div>
-                    <h2 class="section-title mb-4">Entre os líderes que moldam o futuro</h2>
+                    <h2 class="section-title mb-4">Menção na Forbes</h2>
                     <p class="mb-4">
-                        Ser reconhecido pela Forbes entre os principais CTOs do Brasil não é apenas
-                        uma conquista pessoal - é a validação de uma jornada dedicada a
-                        <span class="about-highlight">transformar empresas através da tecnologia</span>.
-                    </p>
-                    <p>
-                        Este convite exclusivo me colocou ao lado dos visionários que estão
-                        redefinindo o cenário tecnológico brasileiro, reforçando meu compromisso
-                        de continuar liderando com inovação e propósito.
+                        Fui citado pela Forbes em matéria sobre liderança em tecnologia no Brasil.
                     </p>
                 </div>
                 <div class="col-lg-6" data-aos="fade-up">
@@ -252,10 +230,10 @@
     <section id="midia" data-aos="fade-up">
         <div class="container">
             <div class="section-header">
-                <div class="section-badge">// RECONHECIMENTO</div>
-                <h2 class="section-title">Voz da inovação na mídia</h2>
+                <div class="section-badge">// MÍDIA</div>
+                <h2 class="section-title">Na mídia</h2>
                 <p class="section-subtitle">
-                    Compartilhando insights sobre o futuro da tecnologia
+                    Aparições e colaborações em veículos nacionais.
                 </p>
             </div>
 
@@ -296,9 +274,9 @@
         <div class="container">
             <div class="section-header">
                 <div class="section-badge">// JORNADA</div>
-                <h2 class="section-title">Cada desafio, uma oportunidade</h2>
+                <h2 class="section-title">Trajetória</h2>
                 <p class="section-subtitle">
-                    Uma trajetória construída transformando empresas e liderando com propósito
+                    Onde trabalhei e o que fiz em cada lugar.
                 </p>
             </div>
 
@@ -310,10 +288,8 @@
                         <div class="timeline-date">2025 - Atual</div>
                         <h4 class="timeline-title">Faculdade São Leopoldo Mandic • Head de Engenharia, Dados e IA</h4>
                         <p class="timeline-description">
-                            Revolucionando a educação médica e odontológica através da inteligência
-                            artificial. Criando plataformas de aprendizado adaptativo e ferramentas
-                            de diagnóstico assistido por IA que preparam os profissionais de saúde
-                            para o futuro da medicina digital.
+                            Lidero engenharia, dados e IA na faculdade. Trabalho em plataformas
+                            de aprendizado e em ferramentas de apoio à formação médica e odontológica.
                         </p>
                     </div>
                 </div>
@@ -324,10 +300,8 @@
                         <div class="timeline-date">2025 - Atual</div>
                         <h4 class="timeline-title">BF Holding • Partner & Executive</h4>
                         <p class="timeline-description">
-                            Liderando a transformação digital do grupo através de iniciativas
-                            tecnológicas estratégicas. Desenvolvendo novos modelos de negócio
-                            baseados em IA e criando sinergias entre as empresas do portfólio
-                            para acelerar crescimento e inovação.
+                            Partner da holding. Atuo em iniciativas de tecnologia e produto
+                            entre as empresas do portfólio.
                         </p>
                     </div>
                 </div>
@@ -340,9 +314,8 @@
                         <div class="timeline-date">2021 - 2025</div>
                         <h4 class="timeline-title">D4Sign • CTO & Sócio</h4>
                         <p class="timeline-description">
-                            Arquitetei o crescimento exponencial que levou ao exit de R$ 180M.
-                            Liderei a transformação tecnológica, expansão internacional e
-                            implementação de IA que revolucionou o mercado de assinaturas digitais.
+                            CTO e sócio da plataforma de assinatura digital. Liderei engenharia
+                            durante o ciclo que culminou no exit de R$180M para o grupo Zucchetti em 2025.
                         </p>
                     </div>
                 </div>
@@ -353,9 +326,8 @@
                         <div class="timeline-date">2020 - 2021</div>
                         <h4 class="timeline-title">dr.consulta • Head de Arquitetura & CISO</h4>
                         <p class="timeline-description">
-                            Revolucionei a infraestrutura tecnológica, migrando para cloud e
-                            criando as bases para IA em saúde. Estabeleci o departamento de
-                            segurança, garantindo proteção de dados de milhões de pacientes.
+                            Head de arquitetura e CISO. Migrei a infraestrutura para cloud e
+                            estruturei o programa de segurança da informação da operação.
                         </p>
                     </div>
                 </div>
@@ -366,9 +338,8 @@
                         <div class="timeline-date">2018 - 2020</div>
                         <h4 class="timeline-title">Sodexo • Global Solutions Architect</h4>
                         <p class="timeline-description">
-                            Projetei soluções globais que impactaram operações em 80 países.
-                            Liderei a modernização de sistemas legados e a criação de
-                            plataformas de pagamento inteligentes.
+                            Solutions architect no time global. Projetei integrações de
+                            pagamento e benefícios em operações internacionais.
                         </p>
                     </div>
                 </div>
@@ -379,9 +350,8 @@
                         <div class="timeline-date">2018</div>
                         <h4 class="timeline-title">Grupo DASA • Líder Técnico</h4>
                         <p class="timeline-description">
-                            Pioneiro na digitalização da saúde diagnóstica. Criei plataformas
-                            multi-cloud que processavam milhões de exames, estabelecendo novos
-                            padrões de eficiência no setor.
+                            Líder técnico em plataformas de diagnóstico. Trabalhei na
+                            infraestrutura multi-cloud que sustentava o processamento de exames.
                         </p>
                     </div>
                 </div>
@@ -394,9 +364,9 @@
         <div class="container">
             <div class="section-header">
                 <div class="section-badge">// PROJETOS PESSOAIS</div>
-                <h2 class="section-title">Criando soluções que inspiram</h2>
+                <h2 class="section-title">Projetos pessoais</h2>
                 <p class="section-subtitle">
-                    Projetos nascidos da paixão por resolver problemas reais com tecnologia elegante
+                    Coisas que construí e mantenho no ar.
                 </p>
             </div>
 
@@ -407,10 +377,8 @@
                     </div>
                     <h4>ChessFrame</h4>
                     <p>
-                        Transforme suas partidas de xadrez em vídeos cinematográficos.
-                        Simplesmente insira a notação dos seus jogos e o ChessFrame
-                        gera automaticamente vídeos profissionais das partidas,
-                        perfeitos para análise, ensino ou compartilhamento.
+                        Gera vídeos a partir de notação de partidas de xadrez. Útil
+                        pra análise, ensino e compartilhamento.
                     </p>
                     <span class="project-link">
                         Explorar projeto <i class="fas fa-arrow-right"></i>
@@ -424,10 +392,8 @@
                     </div>
                     <h4>GoneSheet</h4>
                     <p>
-                        Um frontend completo para planilhas temporárias, projetado
-                        para prototipagem rápida e cálculos instantâneos. Ideal
-                        para quando você precisa de uma planilha poderosa sem
-                        a complexidade de configurações permanentes.
+                        Frontend de planilha temporária, pra prototipagem rápida e
+                        cálculos pontuais sem setup.
                     </p>
                     <span class="project-link">
                         Explorar projeto <i class="fas fa-arrow-right"></i>
@@ -441,10 +407,8 @@
                     </div>
                     <h4>API Fast Mock</h4>
                     <p>
-                        API Fast Mock é um servidor de mock HTTP leve. Em vez de armazenar as configurações de mock no
-                        servidor, cada configuração é comprimida em um token autossuficiente que descreve completamente
-                        o comportamento do endpoint. Essa abordagem sem estado facilita compartilhar, versionar e
-                        reproduzir mocks com uma única URL.
+                        Servidor de mock HTTP sem estado: a configuração do endpoint vira
+                        token na própria URL, fácil de versionar e compartilhar.
                     </p>
                     <span class="project-link">
                         Explorar projeto <i class="fas fa-arrow-right"></i>
@@ -457,10 +421,7 @@
                     </div>
                     <h4>KaleidoImages</h4>
                     <p>
-                        Repositório público com API e mais de 5.000 imagens únicas
-                        geradas por IA no meu laboratório. Um recurso aberto para
-                        desenvolvedores, designers e criadores que precisam de
-                        conteúdo visual de alta qualidade para seus projetos.
+                        Repositório público de 5.000+ imagens geradas por IA, com API aberta.
                     </p>
                     <span class="project-link">
                         Explorar projeto <i class="fas fa-arrow-right"></i>
@@ -473,9 +434,7 @@
                     </div>
                     <h4>Dropp.news</h4>
                     <p>
-                        Portal de notícias ultradinâmico que entrega informação em stories
-                        e threads, com conteúdo gerado e curado por IA para manter você
-                        atualizado em segundos.
+                        Portal de notícias em stories e threads, com curadoria assistida por IA.
                     </p>
                     <span class="project-link">
                         Explorar projeto <i class="fas fa-arrow-right"></i>
@@ -490,7 +449,7 @@
         <div class="container">
             <div class="section-header">
                 <div class="section-badge">// ALÉM DO CÓDIGO</div>
-                <h2 class="section-title">Paixões que me definem</h2>
+                <h2 class="section-title">Além do código</h2>
             </div>
 
             <div class="skills-grid">
@@ -498,7 +457,7 @@
                     <i class="fas fa-music skill-icon"></i>
                     <div>
                         <h5>Música Clássica & Violino</h5>
-                        <p>A disciplina das partituras reflete no código</p>
+                        <p>Escuto música clássica. Estudo violino.</p>
                     </div>
                 </div>
 
@@ -506,7 +465,7 @@
                     <i class="fas fa-brain skill-icon"></i>
                     <div>
                         <h5>Psicologia da Tecnologia</h5>
-                        <p>Entendendo o impacto humano da inovação</p>
+                        <p>Leio sobre o impacto humano das decisões de produto.</p>
                     </div>
                 </div>
 
@@ -514,7 +473,7 @@
                     <i class="fas fa-flask skill-icon"></i>
                     <div>
                         <h5>Laboratório de IA</h5>
-                        <p>Onde o futuro é prototipado hoje</p>
+                        <p>Mantenho um lab pessoal pra experimentar com IA.</p>
                     </div>
                 </div>
 
@@ -522,7 +481,7 @@
                     <i class="fas fa-network-wired skill-icon"></i>
                     <div>
                         <h5>IoT & Automação</h5>
-                        <p>Transformando espaços em ambientes inteligentes</p>
+                        <p>Gosto de mexer com automação residencial e IoT.</p>
                     </div>
                 </div>
 
@@ -530,7 +489,7 @@
                     <i class="fas fa-graduation-cap skill-icon"></i>
                     <div>
                         <h5>Aprendizado Contínuo</h5>
-                        <p>FIAP, IFSP e a universidade da vida</p>
+                        <p>Formação em FIAP e IFSP. Continuo estudando.</p>
                     </div>
                 </div>
 
@@ -538,7 +497,7 @@
                     <i class="fas fa-globe skill-icon"></i>
                     <div>
                         <h5>Poliglota Digital</h5>
-                        <p>Fluente em 3 idiomas e infinitas linguagens</p>
+                        <p>Falo três idiomas.</p>
                     </div>
                 </div>
             </div>
@@ -550,9 +509,9 @@
         <div class="container">
             <div class="section-header">
                 <div class="section-badge">// CONTATO</div>
-                <h2 class="section-title">Vamos construir o futuro juntos?</h2>
+                <h2 class="section-title">Contato</h2>
                 <p class="section-subtitle">
-                    Sempre aberto para conversas sobre tecnologia, inovação e novos desafios
+                    Aberto a conversas sobre tecnologia, produto e IA.
                 </p>
             </div>
 
@@ -595,7 +554,7 @@
     <!-- 10. Footer -->
     <footer>
         <div class="container">
-            <p class="mb-0">&copy; 2024 Bruno Kawakami • Arquitetando o amanhã, hoje</p>
+            <p class="mb-0">&copy; 2026 Bruno Kawakami</p>
         </div>
     </footer>
 


### PR DESCRIPTION
- Tagline trocada para "CTO e Engenheiro de IA" (era "Arquiteto de Futuros Digitais")
- Hero, sobre, Forbes, jornada, projetos, skills e contato reescritos em primeira
  pessoa factual, sem "revolucionei/arquitetei/impossível/visionário"
- Stats grid reduzido de 6 para 4 cards, mantendo só métricas verificáveis
  (R$180M exit D4Sign, 3 patentes, 4 anos como CTO, 10+ anos de liderança)
- Seção Forbes calibrada: sem "entre os principais CTOs do Brasil"
- Descrições da timeline trocadas por 2-3 linhas factuais por cargo
- Copyright atualizado para 2026